### PR TITLE
Fix typo in pg_settings

### DIFF
--- a/pg_collector.sql
+++ b/pg_collector.sql
@@ -4331,7 +4331,7 @@ select * from  rds_aurora.limitless_stat_subclusters;
 \qecho <br>
 select *  from pg_settings where name like '%limitless%'  order by name;
 \qecho <br>
-SELECT *  FROM pg_settings where name in ('max_worker_processes','max_prepared_transactions','enable_partitionwise_aggregate','venable_partitionwise_join','default_transaction_isolation') order by category;
+SELECT *  FROM pg_settings where name in ('max_worker_processes','max_prepared_transactions','enable_partitionwise_aggregate','enable_partitionwise_join','default_transaction_isolation') order by category;
 
 \qecho </details>
 \qecho <center>[<a class="noLink" href="#top">Top</a>]</center><p>


### PR DESCRIPTION
This typo appears to only exist on the postgres 16, 17, and 18 branches

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
